### PR TITLE
MessageClackData v.5 equals() member fixed 

### DIFF
--- a/src/MessageClackData.java
+++ b/src/MessageClackData.java
@@ -28,7 +28,7 @@ public class MessageClackData extends ClackData {
         return this.getUserName() == messageClackData.getUserName() &&
                 this.message == messageClackData.message &&
                 this.getType() == messageClackData.getType() &&
-                this.getDate() == messageClackData.getDate();
+                this.getDate().equals(messageClackData.getDate());
     }
 
     public String toString() {


### PR DESCRIPTION
equals() member fixed when date comparison was switched from '==' binary operator to .equals() member.